### PR TITLE
Updated archive.org URL

### DIFF
--- a/HDL-Batch-installer-SRC/ArtMan.cpp
+++ b/HDL-Batch-installer-SRC/ArtMan.cpp
@@ -153,7 +153,7 @@ long ArtMan::Request_art(wxString ELF, wxString suffix)
     wxString gauge_switch = (FAST->IsChecked()) ? "" : "--show-progress ";
     wxString cert_switch =  (CheckCERT->IsChecked()) ? "--no-check-certificate " : "";
     long wget_return_value;
-    wxString command = "common\\wget.exe -q " + cert_switch + gauge_switch +"https://ia802706.us.archive.org/view_archive.php?archive=/4/items/OPLM_ART_2023_07/OPLM_ART_2023_07.zip&file=PS2%2F";
+    wxString command = "common\\wget.exe -q " + cert_switch + gauge_switch +"https://archive.org/download/OPLM_ART_2023_07/OPLM_ART_2023_07.zip/PS2%2F";
     command.append(ELF);
     command.append("%2F");
     command.append(ELF);


### PR DESCRIPTION
## What was done?

Updated archive.org URL.

## Why was this done?

ia802706 was not working for me. So I replaced it with the generic archive.org URL, and now the proper server resolution should be up to archives.org domain.

If you look closely, its the same URL that the directory listing gives us:
https://ia600609.us.archive.org/view_archive.php?archive=/14/items/OPLM_ART_2023_07/OPLM_ART_2023_07.zip