### PR TITLE
Update default ART url to 2024_09, request PNGs, and copy THM/APPS fo…

### DIFF
--- a/HDL-Batch-installer-SRC/ArtMan.cpp
+++ b/HDL-Batch-installer-SRC/ArtMan.cpp
@@ -157,9 +157,9 @@ long ArtMan::Request_art(wxString ELF, wxString suffix)
     command.append(ELF);
     command.append("%2F");
     command.append(ELF);
-    if (suffix == "_BG.jpg")
+    if (suffix == "_BG.png")
     {
-        command.append("_BG_00.jpg");   ///BG is a special case...
+        command.append("_BG_00.png");   ///BG is a special case...
     }
     else
     {
@@ -206,15 +206,15 @@ void ArtMan::OndownloadClick(wxCommandEvent& event)
         COLOR(07)
         if (bg->GetValue())
         {
-            Request_art(wxString(ELF), "_BG.jpg");
+            Request_art(wxString(ELF), "_BG.png");
         }
         if (cov->GetValue())
         {
-            Request_art(ELF, "_COV.jpg");
+            Request_art(ELF, "_COV.png");
         }
         if (cov2->GetValue())
         {
-            Request_art(ELF, "_COV2.jpg");
+            Request_art(ELF, "_COV2.png");
         }
         if (ico->GetValue())
         {
@@ -222,7 +222,7 @@ void ArtMan::OndownloadClick(wxCommandEvent& event)
         }
         if (lab->GetValue())
         {
-            Request_art(ELF, "_LAB.jpg");
+            Request_art(ELF, "_LAB.png");
         }
         if (lgo->GetValue())
         {
@@ -230,11 +230,11 @@ void ArtMan::OndownloadClick(wxCommandEvent& event)
         }
         if (scr->GetValue())
         {
-            Request_art(ELF, "_SCR_00.jpg");
+            Request_art(ELF, "_SCR_00.png");
         }
         if (scr_2->GetValue())
         {
-            Request_art(ELF, "_SCR_01.jpg");
+            Request_art(ELF, "_SCR_01.png");
         }
         if (cfg->GetValue())
         {

--- a/HDL-Batch-installer-SRC/DokanMan.cpp
+++ b/HDL-Batch-installer-SRC/DokanMan.cpp
@@ -7,6 +7,7 @@
 #include <wx/dir.h>
 #include <wx/fileconf.h>
 #include <wx/msgdlg.h>
+#include <wx/filename.h>
 
 //(*InternalHeaders(DokanMan)
 #include <wx/intl.h>
@@ -357,6 +358,66 @@ void DokanMan::OnART_TRANSFERClick(wxCommandEvent& event)
             genericgaugepercent(RD3S(x, filelist.GetCount()), TMP.ToStdString());
             wxCopyFile(filelist.Item(x), MOUNTBASE+ TMP);
             if (wxFileExists(MOUNTBASE+TMP)) wxRemoveFile(filelist.Item(x));
+        }
+    }
+    COLOR(07)
+    //-----------------------------------THEMES (THM)
+    if (wxDirExists(EXEC_PATH+"Downloads\\THM"))
+    {
+        filelist.clear();
+        curdir_handler->GetAllFiles(EXEC_PATH+"Downloads\\THM",&filelist,"*.*",wxDIR_FILES);
+        MOUNTBASE = MOUNTPOINT+":\\";
+        if (!PART.StartsWith("+")) MOUNTBASE.append("OPL\\");
+        MOUNTBASE.append("THM\\");
+        if (!wxDirExists(MOUNTBASE)) wxMkDir(MOUNTBASE);
+        COLOR(0d)
+        for (size_t x = 0 ; x < filelist.GetCount() ; x++)
+        {
+            TMP = filelist.Item(x);
+            wxString relative_path = TMP.Mid((EXEC_PATH + "Downloads\\THM\\").Length());
+            wxString dest_file = MOUNTBASE + relative_path;
+            
+            // Ensure destination directory exists (for subdirectories like thm_XXXX)
+            wxFileName dest_fn(dest_file);
+            wxString dest_dir = dest_fn.GetPath();
+            if (!wxDirExists(dest_dir))
+            {
+                wxFileName::Mkdir(dest_dir, wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
+            }
+            
+            genericgaugepercent(RD3S(x, filelist.GetCount()), dest_fn.GetFullName().ToStdString());
+            wxCopyFile(TMP, dest_file);
+            if (wxFileExists(dest_file)) wxRemoveFile(TMP);
+        }
+    }
+    COLOR(07)
+    //-----------------------------------APPLICATIONS (APPS)
+    if (wxDirExists(EXEC_PATH+"Downloads\\APPS"))
+    {
+        filelist.clear();
+        curdir_handler->GetAllFiles(EXEC_PATH+"Downloads\\APPS",&filelist,"*.*",wxDIR_FILES);
+        MOUNTBASE = MOUNTPOINT+":\\";
+        if (!PART.StartsWith("+")) MOUNTBASE.append("OPL\\");
+        MOUNTBASE.append("APPS\\");
+        if (!wxDirExists(MOUNTBASE)) wxMkDir(MOUNTBASE);
+        COLOR(0d)
+        for (size_t x = 0 ; x < filelist.GetCount() ; x++)
+        {
+            TMP = filelist.Item(x);
+            wxString relative_path = TMP.Mid((EXEC_PATH + "Downloads\\APPS\\").Length());
+            wxString dest_file = MOUNTBASE + relative_path;
+            
+            // Ensure destination directory exists (for subdirectories)
+            wxFileName dest_fn(dest_file);
+            wxString dest_dir = dest_fn.GetPath();
+            if (!wxDirExists(dest_dir))
+            {
+                wxFileName::Mkdir(dest_dir, wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
+            }
+            
+            genericgaugepercent(RD3S(x, filelist.GetCount()), dest_fn.GetFullName().ToStdString());
+            wxCopyFile(TMP, dest_file);
+            if (wxFileExists(dest_file)) wxRemoveFile(TMP);
         }
     }
     COLOR(07)

--- a/HDL-Batch-installer-SRC/HDL_Batch_installerMain.cpp
+++ b/HDL-Batch-installer-SRC/HDL_Batch_installerMain.cpp
@@ -543,7 +543,7 @@ HDL_Batch_installerFrame::HDL_Batch_installerFrame(wxWindow* parent, wxLocale& l
         COLOR(0c) cerr << "Can't load config file!\n  Loading default values\n";
     }
     main_config->Read("Installation/DataBase_Mode", &CFG::DBMODE, DB_INTERNAL);
-    main_config->Read("Artwork/DataBaseURL", &CFG_ARTURL, "https://archive.org/download/OPLM_ART_2023_07/OPLM_ART_2023_07.zip/PS2%2F");
+    main_config->Read("Artwork/DataBaseURL", &CFG_ARTURL, "https://archive.org/download/OPLM_ART_2024_09/OPLM_ART_2024_09.zip/PS2%2F");
     main_config->Read("Init/Debug_level", &CFG::DEBUG_LEVEL, 5);
     main_config->Read("Installation/MiniOPL", &CFG::MINIOPL_WARNING, 1);
     main_config->Read("Installation/OSD_Hide", &CFG::OSD_HIDE, 0);


### PR DESCRIPTION
- update the ART archive URL from the newest one from https://archive.org/download/OPLM_ART_2024_09/OPLM_ART_2024_09.zip,
- update jpg by png for backgrounds
- add tranfers for APPS and THM folders from the download folders. same behaviour as others folders (especially if these folders doesn't exist). 